### PR TITLE
fix: add sts:TagSession action to the user profile role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,9 @@
 data "aws_iam_policy_document" "assume_policy" {
   statement {
-    actions = ["sts:AssumeRole"]
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
     principals {
       type = "Service"
       identifiers = [


### PR DESCRIPTION
add `sts:TagSession` action to the user profile role